### PR TITLE
Cleanup imports, examples, and fix typos

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,13 @@
     "test-watch": "tsdx test --watch"
   },
   "peerDependencies": {
-    "@reduxjs/toolkit": "1.4.x",
-    "redux": "4.0.x"
+    "@reduxjs/toolkit": "1.4.x"
   },
   "devDependencies": {
     "@vmw/eslint-config-vmware-react": "0.1.0",
     "@types/jest": "26.0.13",
     "@reduxjs/toolkit": "1.4.0",
     "husky": "4.3.0",
-    "redux": "4.0.5",
     "tsdx": "0.13.3",
     "tslib": "2.0.1",
     "typescript": "3.9.6"

--- a/src/create-slice.ts
+++ b/src/create-slice.ts
@@ -1,10 +1,10 @@
 /* Copyright 2020 VMware, Inc.
  * SPDX-License-Identifier: MIT */
 
-// Use the immer version used by @reduxjs/toolkit
-// eslint-disable-next-line import/no-extraneous-dependencies
-import createNewState, { Draft } from 'immer';
 import {
+  // Use the immer version used by @reduxjs/toolkit
+  createNextState,
+  Draft,
   createAction as rtkCreateAction,
   CaseReducer,
   CaseReducerActions,
@@ -174,7 +174,7 @@ export function createSlice<State>(
   ): State {
     const caseReducer = sliceCaseReducersByType[action.type];
     if (immer) {
-      return createNewState(sliceState, (draft: Draft<State>) => {
+      return createNextState(sliceState, (draft: Draft<State>) => {
         return caseReducer ? caseReducer(draft, action) : undefined;
       }) as State;
     }

--- a/src/internal/mutable-combine-reducer.ts
+++ b/src/internal/mutable-combine-reducer.ts
@@ -1,8 +1,7 @@
 /* Copyright 2020 VMware, Inc.
  * SPDX-License-Identifier: MIT */
 
-import { Reducer } from 'redux';
-import { AnyAction } from '@reduxjs/toolkit';
+import { Reducer, AnyAction } from '@reduxjs/toolkit';
 
 type Reducers = { [reducerName: string]: Reducer };
 

--- a/src/root-slice-group.ts
+++ b/src/root-slice-group.ts
@@ -1,7 +1,7 @@
 /* Copyright 2020 VMware, Inc.
  * SPDX-License-Identifier: MIT */
 
-import { Reducer } from 'redux';
+import { Reducer } from '@reduxjs/toolkit';
 import { PATH_SEPARATOR } from './constants';
 import { createMutableCombineReducer } from './internal/mutable-combine-reducer';
 

--- a/website/docs/api/Slice.md
+++ b/website/docs/api/Slice.md
@@ -37,8 +37,8 @@ The action creators are generated using the <a href="https://redux-toolkit.js.or
 
 ### `addExtraReducers(extraReducers)`
 
-Like caseReducers, extraReducers should be an object containing Redux case reducer functions. However, the keys should be string action type constants.
-addExtraReducers will not auto-generate action types nor action creators for extraReducers and it has no return value.
+Like `caseReducers`, `extraReducers` should be an object containing Redux case reducer functions. However, the keys should be string action type constants.
+`addExtraReducers` will not auto-generate action types nor action creators for extraReducers and it has no return value.
 
 ### `createAction(actionKey)`
 

--- a/website/docs/api/createSlice.md
+++ b/website/docs/api/createSlice.md
@@ -68,7 +68,7 @@ Optional - The Slice's reducer uses, or not uses <a href="https://github.com/imm
 
 Default value is: true  
 When migrating to **Slices for Redux** you may find that some existing code mutates the state.  
-To **temporary ignore** impure code until it can be fixed set `immer` to false.  
+To **temporarily ignore** impure code until it can be fixed set `immer` to false.  
 When `immer` is false, a warning will appear in the console.
 
 ### `name`
@@ -84,7 +84,7 @@ Default value is: [`rootSliceGroup`](/slices-for-redux/docs/api/rootSliceGroup)
 When `parent` is [`rootSliceGroup`](/slices-for-redux/docs/api/rootSliceGroup) this [`Slice`](/slices-for-redux/docs/api/Slice)'s `reducer` will be added to the [`rootReducer`](/slices-for-redux/docs/api/rootReducer).  
 When `parent` is a [`SliceParent`](/slices-for-redux/docs/api/SliceParent), this [`Slice`](/slices-for-redux/docs/api/Slice)'s `reducer` will be added to that parent's reducer.  
 When `parent` is a string, it represents the parent's path, and this
-[`Slice`](/slices-for-redux/docs/api/Slice)'s reducer will needs to be manually added to that parent's reducer.
+[`Slice`](/slices-for-redux/docs/api/Slice)'s reducer will need to be manually added to that parent's reducer.
 
 ## Return Value
 

--- a/website/docs/internal/_extra.md
+++ b/website/docs/internal/_extra.md
@@ -102,7 +102,7 @@ We recommend using this API if stricter type safety is necessary when defining r
 Each function defined in the `reducers` argument will have a corresponding action creator generated using [`createAction`](/slices-for-redux/docs/api/createAction)
 and included in the result's `actions` field using the same function name.
 
-The generated `reducer` function is suitable for passing to the Redux `combineReducers` function as a "slice reducer".
+The generated `reducer` function is suitable for passing to the Redux `combineReducers` function (re-exported by RTK) as a "slice reducer".
 
 You may want to consider destructuring the action creators and exporting them individually, for ease of searching
 for references in a larger codebase.
@@ -110,8 +110,13 @@ for references in a larger codebase.
 ## Examples
 
 ```ts
-import { createSlice, createAction, PayloadAction } from '@reduxjs/toolkit';
-import { createStore, combineReducers } from 'redux';
+import {
+  configureStore,
+  combineReducers,
+  createSlice,
+  createAction,
+  PayloadAction,
+} from '@reduxjs/toolkit';
 
 const incrementBy = createAction<number>('incrementBy');
 
@@ -137,13 +142,13 @@ const user = createSlice({
   name: 'user',
   initialState: { name: '', age: 20 },
   reducers: {
-    setUserName: (state, action) => {
+    setUserName: (state, action: PayloadAction<string>) => {
       state.name = action.payload; // mutate the state all you want with immer
     },
   },
   // "map object API"
   extraReducers: {
-    [counter.actions.increment]: (state, action) => {
+    [counter.actions.increment]: (state, action: PayloadAction<number>) => {
       state.age += 1;
     },
   },
@@ -154,7 +159,7 @@ const reducer = combineReducers({
   user: user.reducer,
 });
 
-const store = createStore(reducer);
+const store = configureStore({ reducer });
 
 store.dispatch(counter.actions.increment());
 // -> { counter: 1, user: {name : '', age: 21} }

--- a/website/docs/introduction/quick-start.md
+++ b/website/docs/introduction/quick-start.md
@@ -40,15 +40,14 @@ npm install --save @vmw/slices-for-redux
 yarn add @vmw/slices-for-redux
 ```
 
-Note: [Redux Toolkit `@reduxjs/toolkit`](https://redux-toolkit.js.org/) a require peer dependency
+Note: [Redux Toolkit `@reduxjs/toolkit`](https://redux-toolkit.js.org/) is a required peer dependency
 
 ## Use the rootSliceGroup's reducer
 
 Replace code like this:
 
 ```ts
-import { combineReducers } from 'redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 const rootReducer = combineReducers({
   [homeSlice.name]: homeSlice.reducer,
@@ -66,12 +65,12 @@ With code like this:
 import { rootSliceGroup } from 'slices-for-redux';
 import { configureStore } from '@reduxjs/toolkit';
 
-rootSliceGroup.addReducers({
+const { reducer } = rootSliceGroup.addReducers({
   [homeSlice.name]: homeSlice.reducer,
   [todoSlice.name]: todoSlice.reducer,
 });
 
 const store = configureStore({
-  reducer: rootSliceGroup.reducer,
+  reducer,
 });
 ```


### PR DESCRIPTION
- Updates examples to be uniform - uses `configureStore` everywhere
- Uses the types from RTK as they're re-exported from Redux
- Addresses misc. typos

Signed-off-by: Matt Sutkowski <msutkowski@gmail.com>